### PR TITLE
se agregaron los endpoints de updates de password y email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <quarkus.platform.version>3.22.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
+        <lombok.version>1.18.36</lombok.version>
     </properties>
 
     <dependencyManagement>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -66,7 +67,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-mysql</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.google.firebase/firebase-admin -->
         <dependency>
             <groupId>com.google.firebase</groupId>
             <artifactId>firebase-admin</artifactId>
@@ -101,6 +101,13 @@
                 <version>${compiler-plugin.version}</version>
                 <configuration>
                     <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/life/pahtlicoo/application/dto/sysuser/UpdateEmailRequestDTO.java
+++ b/src/main/java/life/pahtlicoo/application/dto/sysuser/UpdateEmailRequestDTO.java
@@ -1,0 +1,16 @@
+package life.pahtlicoo.application.dto.sysuser;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateEmailRequestDTO {
+    private int sysUserId;
+    private String newEmail;
+    private String firebaseId;
+}

--- a/src/main/java/life/pahtlicoo/application/dto/sysuser/UpdateEmailUnifiedRequestDTO.java
+++ b/src/main/java/life/pahtlicoo/application/dto/sysuser/UpdateEmailUnifiedRequestDTO.java
@@ -1,0 +1,16 @@
+package life.pahtlicoo.application.dto.sysuser;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateEmailUnifiedRequestDTO {
+    private int sysUserId;
+    private String firebaseId;
+    private String newEmail;
+}

--- a/src/main/java/life/pahtlicoo/application/dto/sysuser/UpdatePasswordRequestDTO.java
+++ b/src/main/java/life/pahtlicoo/application/dto/sysuser/UpdatePasswordRequestDTO.java
@@ -1,0 +1,16 @@
+package life.pahtlicoo.application.dto.sysuser;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePasswordRequestDTO {
+    private int sysUserId;
+    private String firebaseId;
+    private String newPassword;
+}

--- a/src/main/java/life/pahtlicoo/application/dto/sysuser/UserResponseDTO.java
+++ b/src/main/java/life/pahtlicoo/application/dto/sysuser/UserResponseDTO.java
@@ -1,0 +1,18 @@
+package life.pahtlicoo.application.dto.sysuser;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDTO {
+    private int sysUserId;
+    private String name;
+    private String lastName;
+    private String email;
+    private String firebaseId;
+}

--- a/src/main/java/life/pahtlicoo/application/mapper/UserResponseMapper.java
+++ b/src/main/java/life/pahtlicoo/application/mapper/UserResponseMapper.java
@@ -1,0 +1,22 @@
+package life.pahtlicoo.application.mapper;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import life.pahtlicoo.domain.model.SysUser;
+import life.pahtlicoo.application.dto.sysuser.UserResponseDTO;
+
+
+@ApplicationScoped
+public class UserResponseMapper {
+
+    public UserResponseDTO toDTO(SysUser sysUser) {
+        if (sysUser == null) {
+            return null;
+        }
+        UserResponseDTO dto = new UserResponseDTO();
+        dto.setSysUserId(sysUser.getSysUserId());
+        dto.setName(sysUser.getName());
+        dto.setLastName(sysUser.getLastName());
+        dto.setEmail(sysUser.getEmail());
+        return dto;
+    }
+}

--- a/src/main/java/life/pahtlicoo/application/service/SysUserService.java
+++ b/src/main/java/life/pahtlicoo/application/service/SysUserService.java
@@ -17,11 +17,12 @@ public class SysUserService {
 
     public SysUser createUser(SysUser sysUser) {
         return sysUserRepository.createSysUser(sysUser);
-    };
+    }
 
     public SysUser createUserFirebase(SysUser user, String password) {
         return sysUserRepository.createSysUserFirebase(user, password);
     }
+
     public Boolean deleteUserFirebase(String userUid){
         return sysUserRepository.deleteSysUserFirebase(userUid);
     }
@@ -30,9 +31,11 @@ public class SysUserService {
         return sysUserRepository.getSysUser(userId);
     }
 
+    // Método para obtener SysUser por Firebase ID
     public SysUser getSysUserByFirebaseId(String firebaseId){
         return sysUserRepository.getSysUserByFirebaseId(firebaseId);
     }
+
     public SysUser updateSysUserEmail(int sysUserId, String newEmail) {
         SysUser updatedUser = sysUserRepository.updateSysUserEmail(sysUserId, newEmail);
         return updatedUser;

--- a/src/main/java/life/pahtlicoo/application/usecase/sysuser/UpdateUserEmailUseCase.java
+++ b/src/main/java/life/pahtlicoo/application/usecase/sysuser/UpdateUserEmailUseCase.java
@@ -1,0 +1,61 @@
+package life.pahtlicoo.application.usecase.sysuser;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import life.pahtlicoo.application.service.SysUserService;
+import life.pahtlicoo.application.mapper.UserResponseMapper;
+import life.pahtlicoo.application.dto.sysuser.UserResponseDTO;
+import life.pahtlicoo.domain.model.SysUser;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class UpdateUserEmailUseCase {
+
+    private static final Logger LOGGER = Logger.getLogger(UpdateUserEmailUseCase.class.getName());
+
+    @Inject
+    SysUserService sysUserService;
+
+    @Inject
+    UserResponseMapper userResponseMapper;
+
+    public UserResponseDTO executeLocalEmailUpdate(int sysUserId, String newEmail) {
+        if (newEmail == null || !newEmail.contains("@")) {
+            throw new IllegalArgumentException("El email proporcionado es inválido.");
+        }
+        SysUser updatedUser = sysUserService.updateSysUserEmail(sysUserId, newEmail);
+        if (updatedUser == null) {
+            throw new IllegalArgumentException("No se pudo actualizar el email local. Usuario no encontrado o error en el servicio.");
+        }
+        return userResponseMapper.toDTO(updatedUser);
+    }
+
+    // Método para actualizar email en Firebase Authentication
+    public UserResponseDTO executeFirebaseEmailUpdate(String firebaseId, String newEmail) {
+        if (firebaseId == null || firebaseId.isEmpty() || newEmail == null || !newEmail.contains("@")) {
+            throw new IllegalArgumentException("Firebase ID o email inválido.");
+        }
+        try {
+            Boolean success = sysUserService.updateSysUserEmailFirebase(firebaseId, newEmail);
+            if (!success) {
+                throw new IllegalStateException("Fallo interno al actualizar el email en Firebase.");
+            }
+
+            // Usamos el método existente en SysUserService.
+            SysUser updatedSysUser = sysUserService.getSysUserByFirebaseId(firebaseId);
+            if (updatedSysUser == null) {
+                UserResponseDTO dto = new UserResponseDTO();
+                dto.setFirebaseId(firebaseId);
+                dto.setEmail(newEmail);
+                return dto;
+            }
+            updatedSysUser.setEmail(newEmail);
+            return userResponseMapper.toDTO(updatedSysUser);
+
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error al actualizar el email en Firebase: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/life/pahtlicoo/application/usecase/sysuser/UpdateUserPasswordUseCase.java
+++ b/src/main/java/life/pahtlicoo/application/usecase/sysuser/UpdateUserPasswordUseCase.java
@@ -1,0 +1,60 @@
+package life.pahtlicoo.application.usecase.sysuser;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import life.pahtlicoo.application.service.SysUserService;
+import life.pahtlicoo.application.mapper.UserResponseMapper;
+import life.pahtlicoo.application.dto.sysuser.UserResponseDTO;
+import life.pahtlicoo.domain.model.SysUser;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class UpdateUserPasswordUseCase {
+
+    private static final Logger LOGGER = Logger.getLogger(UpdateUserPasswordUseCase.class.getName());
+
+    @Inject
+    SysUserService sysUserService;
+
+    @Inject
+    UserResponseMapper userResponseMapper;
+
+    // Método para actualizar contraseña en la base de datos local
+
+    public UserResponseDTO executePasswordUpdate(int sysUserId, String newPassword) {
+        if (newPassword == null || newPassword.length() < 8 || !newPassword.matches(".*[A-Z].*") || !newPassword.matches(".*[0-9].*")) {
+            throw new IllegalArgumentException("Contraseña inválida. Debe tener al menos 8 caracteres, una mayúscula y un número.");
+        }
+        SysUser updatedUser = sysUserService.updateSysUserPassword(sysUserId, newPassword);
+        if (updatedUser == null) {
+            throw new IllegalArgumentException("No se pudo actualizar la contraseña local. Usuario no encontrado o error en el servicio.");
+        }
+        return userResponseMapper.toDTO(updatedUser);
+    }
+
+    // Método para actualizar contraseña en Firebase Authentication
+    public UserResponseDTO executeFirebasePasswordUpdate(String firebaseId, String newPassword) {
+        if (firebaseId == null || firebaseId.isEmpty() || newPassword == null || newPassword.length() < 8) {
+            throw new IllegalArgumentException("Firebase ID o contraseña inválida (mínimo 8 caracteres).");
+        }
+        try {
+            Boolean success = sysUserService.updateSysUserPasswordFirebase(firebaseId, newPassword);
+            if (!success) {
+                throw new IllegalStateException("Fallo interno al actualizar la contraseña directamente en Firebase.");
+            }
+
+            SysUser updatedSysUser = sysUserService.getSysUserByFirebaseId(firebaseId);
+            if (updatedSysUser == null) {
+                UserResponseDTO dto = new UserResponseDTO();
+                dto.setFirebaseId(firebaseId);
+                return dto;
+            }
+            return userResponseMapper.toDTO(updatedSysUser);
+
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error al actualizar la contraseña en Firebase: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/life/pahtlicoo/infrastructure/controller/SysUserController.java
+++ b/src/main/java/life/pahtlicoo/infrastructure/controller/SysUserController.java
@@ -2,26 +2,54 @@ package life.pahtlicoo.infrastructure.controller;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.validation.Valid;
 
+
 import life.pahtlicoo.application.dto.sysuser.CreateSysUserReqDTO;
 import life.pahtlicoo.application.dto.sysuser.UserFirebaseContentDTO;
 import life.pahtlicoo.application.dto.sysuser.UserRequestResponseDTO;
+import life.pahtlicoo.application.dto.sysuser.UpdateEmailRequestDTO;
+import life.pahtlicoo.application.dto.sysuser.UpdatePasswordRequestDTO;
+import life.pahtlicoo.application.dto.sysuser.UserResponseDTO;
+import life.pahtlicoo.application.dto.sysuser.UpdateEmailUnifiedRequestDTO;
+
+
 import life.pahtlicoo.application.usecase.sysuser.CreateSysUserUseCase;
 import life.pahtlicoo.application.usecase.sysuser.GetUserByFirebaseId;
+import life.pahtlicoo.application.usecase.sysuser.UpdateUserEmailUseCase;
+import life.pahtlicoo.application.usecase.sysuser.UpdateUserPasswordUseCase;
+
+
+import life.pahtlicoo.application.mapper.UserResponseMapper;
+
 import life.pahtlicoo.domain.model.SysUser;
 import life.pahtlicoo.shared.annotation.NoAuthRequired;
 
 @Path("/sys-user")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class SysUserController {
+
     @Inject
     CreateSysUserUseCase createUserUseCase;
     @Inject
     GetUserByFirebaseId getUserByFirebaseId;
+
+    @Inject
+    UpdateUserEmailUseCase updateUserEmailUseCase;
+    @Inject
+    UpdateUserPasswordUseCase updateUserPasswordUseCase;
+
+    @Inject
+    UserResponseMapper userResponseMapper;
+
 
     @POST
     @Path("/create")
@@ -48,7 +76,115 @@ public class SysUserController {
         }catch (Exception e){
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
         }
-
     }
 
+
+    // Este endpoint actualiza el email en la base de datos local
+    @POST
+    @Path("/update-email")
+    public Response updateEmail(@Valid UpdateEmailRequestDTO requestDTO) {
+        try {
+            UserResponseDTO updatedSysUserDTO = updateUserEmailUseCase.executeLocalEmailUpdate(
+                    requestDTO.getSysUserId(), requestDTO.getNewEmail()
+            );
+            return Response.ok(updatedSysUserDTO).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Error al actualizar el email local: " + e.getMessage())
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error interno al actualizar el email local: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    // Este endpoint actualiza la contraseña en la base de datos local
+    @POST
+    @Path("/update-password")
+    public Response updatePassword(@Valid UpdatePasswordRequestDTO requestDTO) {
+        try {
+            UserResponseDTO updatedSysUserDTO = updateUserPasswordUseCase.executePasswordUpdate(
+                    requestDTO.getSysUserId(), requestDTO.getNewPassword()
+            );
+            return Response.ok(updatedSysUserDTO).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Error al actualizar la contraseña local: " + e.getMessage())
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error interno al actualizar la contraseña local: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    // Este endpoint actualiza el email SOLO en Firebase
+    @POST
+    @Path("/firebase/update-email")
+    public Response updateFirebaseEmail(@Valid UpdateEmailRequestDTO requestDTO) {
+        try {
+            UserResponseDTO resultDTO = updateUserEmailUseCase.executeFirebaseEmailUpdate(
+                    requestDTO.getFirebaseId(), requestDTO.getNewEmail()
+            );
+            return Response.ok(resultDTO).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Error al actualizar el email en Firebase: " + e.getMessage())
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error interno al actualizar el email en Firebase: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    // Este endpoint actualiza la contraseña SOLO en Firebase
+    @POST
+    @Path("/firebase/update-password")
+    public Response updateFirebasePassword(@Valid UpdatePasswordRequestDTO requestDTO) {
+        try {
+            UserResponseDTO resultDTO = updateUserPasswordUseCase.executeFirebasePasswordUpdate(
+                    requestDTO.getFirebaseId(), requestDTO.getNewPassword()
+            );
+            return Response.ok(resultDTO).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Error al actualizar la contraseña en Firebase: " + e.getMessage())
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error interno al actualizar la contraseña en Firebase: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    @POST
+    @Path("/unified-update-email") // Ruta para el endpoint unificado
+    public Response unifiedUpdateEmail(@Valid UpdateEmailUnifiedRequestDTO requestDTO) {
+        try {
+            // 1. Actualizar el email en Firebase primero
+            updateUserEmailUseCase.executeFirebaseEmailUpdate(
+                    requestDTO.getFirebaseId(),
+                    requestDTO.getNewEmail()
+            );
+
+            // 2. Si Firebase fue exitoso, actualizar el email en la base de datos local
+            UserResponseDTO localUpdateResult = updateUserEmailUseCase.executeLocalEmailUpdate(
+                    requestDTO.getSysUserId(),
+                    requestDTO.getNewEmail()
+            );
+
+            return Response.ok(localUpdateResult).build();
+
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Error unificado al actualizar el email: " + e.getMessage())
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error interno del servidor al actualizar el email de forma unificada: " + e.getMessage())
+                    .build();
+        }
+    }
 }


### PR DESCRIPTION
Se añadió el endpoint para actualizar contraseña en Firebase e email tanto local como Firebase.
Se utilizó POSTMAN para las pruebas y si se hace bien, se obtiene una respuesta 200algo y se puede visualizar en la bd local y en Firebase.